### PR TITLE
RFC: add expected throughput as reported by minstrel(_ht)

### DIFF
--- a/lib/bmx7_iwinfo/bmx7_iwinfo.c
+++ b/lib/bmx7_iwinfo/bmx7_iwinfo.c
@@ -131,6 +131,7 @@ void get_link_rate(struct dev_node *tDev)
 
 							oLink->wifiStats.txRate = e->tx_rate.rate * 1000;
 							oLink->wifiStats.txRateAvg = oLink->wifiStats.txRateAvg + (oLink->wifiStats.txRate / linkAvgRateWeight) - (oLink->wifiStats.txRateAvg / linkAvgRateWeight);
+							oLink->wifiStats.txRateExpected = e->thr;
 							oLink->wifiStats.tx40mhz = e->tx_rate.is_40mhz;
 							//link->linkStats.txHt = e->tx_rate.is_ht;
 							oLink->wifiStats.txMcs = e->tx_rate.mcs;

--- a/link.c
+++ b/link.c
@@ -786,6 +786,7 @@ struct link_status {
 	int8_t wRxHt;
 	int8_t wRxVht;
 
+	UMETRIC_T wTxRateExpected;
 	UMETRIC_T wTxRateAvg;
 	UMETRIC_T wTxRate;
 	uint32_t cnt;
@@ -849,6 +850,7 @@ static const struct field_format link_status_format[] = {
 	FIELD_FORMAT_INIT(FIELD_TYPE_UINT,              link_status, wRxVht,           1, FIELD_RELEVANCE_LOW),
 
         FIELD_FORMAT_INIT(FIELD_TYPE_UMETRIC,           link_status, wTxRateAvg,       1, FIELD_RELEVANCE_MEDI),
+        FIELD_FORMAT_INIT(FIELD_TYPE_UMETRIC,           link_status, wTxRateExpected,  1, FIELD_RELEVANCE_MEDI),
         FIELD_FORMAT_INIT(FIELD_TYPE_UMETRIC,           link_status, wTxRate,          1, FIELD_RELEVANCE_HIGH),
 	FIELD_FORMAT_INIT(FIELD_TYPE_UINT,              link_status, cnt,              1, FIELD_RELEVANCE_MEDI),
 	FIELD_FORMAT_INIT(FIELD_TYPE_INT,               link_status, mcs,              1, FIELD_RELEVANCE_HIGH),
@@ -923,6 +925,7 @@ static int32_t link_status_creator(struct status_handl *handl, void *data)
 				status[i].wSnr = link->wifiStats.signal - link->wifiStats.noise;
 				status[i].wTxRate = link->wifiStats.txRate;
 				status[i].wTxRateAvg = link->wifiStats.txRateAvg;
+				status[i].wTxRateExpected = link->wifiStats.txRateExpected;
 				status[i].cnt = link->wifiStats.txPackets;
 				status[i].mcs = link->wifiStats.txMcs;
 				status[i].mhz = link->wifiStats.txMhz;

--- a/node.h
+++ b/node.h
@@ -256,6 +256,7 @@ typedef struct {
 struct LinkStats {
 	UMETRIC_T txRate;
 	UMETRIC_T txRateAvg;
+	UMETRIC_T txRateExpected;
 	uint32_t txPackets;
 	uint32_t txBurstPackets;
 


### PR DESCRIPTION
use libiwinfo to acquire the expected throughput with a specific link
partner. store that information and make use of it in the bandwidth
metrics.