### PR TITLE
iwinfo: recurse down to lowest layer-2 interface

### DIFF
--- a/ip.c
+++ b/ip.c
@@ -3455,12 +3455,8 @@ int32_t opt_dev(uint8_t cmd, uint8_t _save, struct opt_type *opt, struct opt_par
                         strcpy(dev->ifname_label.str, patch->val);
                         strcpy(dev->ifname_device.str, ifname_vlan);
 
-			IDM_T TODO_use_proc_for_getting_parent_ifname;
-			strcpy(dev->ifname_phy.str, ifname_vlan);
-			// if given interface is a vlan then truncate to physical interface name:
-			if ((cptr = strchr(dev->ifname_phy.str, '.')) != NULL)
-				*cptr = '\0';
-
+			if (interface_get_lowest(dev->ifname_phy.str, ifname_vlan) == FAILURE)
+				strcpy(dev->ifname_phy.str, ifname_vlan);
 
                         avl_insert(&dev_name_tree, dev, -300144);
 

--- a/tools.h
+++ b/tools.h
@@ -44,6 +44,9 @@ static inline uint64_t ntoh64(uint64_t x) {
 #define hton64 ntoh64
 
 
+#define NETIF_PREFIX "/sys/class/net/"
+#define VIRTIF_PREFIX "/sys/devices/virtual/net/"
+#define LOWERGLOB_SUFFIX "/lower_*"
 
 
 
@@ -93,6 +96,8 @@ int32_t check_dir(char *path, uint8_t create, uint8_t write, uint8_t onlyBasePat
 int32_t rm_dir_content(char* dir_name, char* prefix);
 
 uint8_t *find_array_data(uint8_t *arr, uint32_t arrLen, uint8_t *element, uint32_t elemLen);
+
+int interface_get_lowest(char *hwifname, const char *ifname);
 
 void init_tools(void);
 


### PR DESCRIPTION
adapted from freifunk-gluon/gluon@4ce85af
fixes #13 (bmx7 not detecting certain wireless interfaces)

UNTESTED! test on real hardware before merge!