### PR TITLE
bmx7-sms: increase max filename length to 32

### DIFF
--- a/lib/bmx7_sms/sms.h
+++ b/lib/bmx7_sms/sms.h
@@ -22,7 +22,7 @@
 
 #define ARG_SMS "syncSms"
 
-#define MAX_SMS_NAME_LEN 16
+#define MAX_SMS_NAME_LEN 32
 #define MAX_SMS_DATA_LEN 300
 #define MAX_SMS_DATA_LEN_REF MAX_VRT_FRAME_DATA_SIZE
 


### PR DESCRIPTION
32 characters should be enough for anyone
I see no reason against longer filenames and it's especially useful when the filenames contain the shortid for remote command execution like [here](https://github.com/aparcar/meshrc/blob/master/packages/meshrc/files/cli.sh)