### PR TITLE
rename list_add_tail and struct list_head

### DIFF
--- a/control.c
+++ b/control.c
@@ -73,7 +73,7 @@ uint32_t My_pid = 0;
 
 LIST_SIMPEL(ctrl_list, struct ctrl_node, list, list);
 
-struct list_head dbgl_clients[DBGL_MAX + 1];
+struct bmx_list_head dbgl_clients[DBGL_MAX + 1];
 static struct dbg_histogram dbgl_history[2][DBG_HIST_SIZE];
 
 static uint8_t debug_system_active = NO;
@@ -136,7 +136,7 @@ void add_dbgl_node(struct ctrl_node *cn, int dbgl)
 
 	dn->cn = cn;
 	cn->dbgl = dbgl;
-	list_add_tail(&dbgl_clients[dbgl], &dn->list);
+	bmx_list_add_tail(&dbgl_clients[dbgl], &dn->list);
 
 	if (dbgl == DBGL_SYS || dbgl == DBGL_CHANGES) {
 		dbgf_all(DBGT_INFO, "resetting muted dbg history");
@@ -255,7 +255,7 @@ struct ctrl_node *create_ctrl_node(int fd, void (*cn_fd_handler) (struct ctrl_no
 {
 	struct ctrl_node *cn = debugMallocReset(sizeof(struct ctrl_node), -300010);
 
-	list_add_tail(&ctrl_list, &cn->list);
+	bmx_list_add_tail(&ctrl_list, &cn->list);
 
 	cn->fd = fd;
 	cn->cn_fd_handler = cn_fd_handler;
@@ -571,7 +571,7 @@ void debug_output(uint32_t check_len, struct ctrl_node *cn, int8_t dbgl, int8_t 
 		if (level == DBGL_SYS && mute_dbgl_sys == DBG_HIST_MUTED)
 			continue;
 
-		list_for_each(list_pos, /*(struct list_head *)*/&(dbgl_clients[level]))
+		list_for_each(list_pos, /*(struct bmx_list_head *)*/&(dbgl_clients[level]))
 		{
 
 			struct dbgl_node *dn = list_entry(list_pos, struct dbgl_node, list);
@@ -990,7 +990,7 @@ void register_option(struct opt_type *opt, const char * category_name)
 
 		opt->d.parent_opt = tmp_opt;
 
-		list_add_tail(&tmp_opt->d.childs_type_list, &opt->d.list);
+		bmx_list_add_tail(&tmp_opt->d.childs_type_list, &opt->d.list);
 
 	} else {
 
@@ -1017,7 +1017,7 @@ void register_option(struct opt_type *opt, const char * category_name)
 		}
 
 		if (!tmp_opt)
-			list_add_tail(&opt_list, &opt->d.list);
+			bmx_list_add_tail(&opt_list, &opt->d.list);
 
 	}
 
@@ -1094,7 +1094,7 @@ struct opt_type *get_option(struct opt_type *parent_opt, uint8_t short_opt, char
 
 	struct list_node *list_pos;
 	int32_t len = 0;
-	struct list_head *list;
+	struct bmx_list_head *list;
 	struct opt_type *opt = NULL;
 	char *equalp = NULL;
 	char s[MAX_ARG_SIZE] = "";
@@ -1305,7 +1305,7 @@ struct opt_child *add_opt_child(struct opt_type *opt, struct opt_parent *p)
 
 	c->opt = opt;
 	c->parent_instance = p;
-	list_add_tail(&p->childs_instance_list, &c->list);
+	bmx_list_add_tail(&p->childs_instance_list, &c->list);
 
 	return c;
 }
@@ -1347,7 +1347,7 @@ struct opt_parent *add_opt_parent(struct opt_type *opt)
 
 	LIST_INIT_HEAD(p->childs_instance_list, struct opt_child, list, list);
 
-	list_add_tail(&opt->d.parents_instance_list, &p->list);
+	bmx_list_add_tail(&opt->d.parents_instance_list, &p->list);
 
 	return p;
 }

--- a/control.h
+++ b/control.h
@@ -49,7 +49,7 @@ typedef uint32_t TIME_SEC_T;
 
 extern int unix_sock;
 
-extern struct list_head ctrl_list;
+extern struct bmx_list_head ctrl_list;
 
 extern int32_t Client_mode;
 
@@ -115,7 +115,7 @@ struct ctrl_node {
 	int8_t dbgl;
 };
 
-extern struct list_head dbgl_clients[DBGL_MAX + 1];
+extern struct bmx_list_head dbgl_clients[DBGL_MAX + 1];
 
 struct dbgl_node {
 	struct list_node list;
@@ -227,7 +227,7 @@ struct ctrl_node *create_ctrl_node(int fd, void (*cn_fd_handler) (struct ctrl_no
 
 #define MAX_UNIX_MSG_SIZE 2000
 
-extern struct list_head opt_list;
+extern struct bmx_list_head opt_list;
 
 
 /* opt_t types:
@@ -292,7 +292,7 @@ struct opt_child {
 struct opt_parent {
 	struct list_node list;
 
-	struct list_head childs_instance_list;
+	struct bmx_list_head childs_instance_list;
 
 	char *val; //key
 
@@ -311,9 +311,9 @@ struct opt_data {
 
 	struct opt_type *parent_opt; //REMOVE THIS and use casting instead !
 
-	struct list_head childs_type_list; //if this opt is a section type, then further sub-opts types can be listed here
+	struct bmx_list_head childs_type_list; //if this opt is a section type, then further sub-opts types can be listed here
 
-	struct list_head parents_instance_list; //
+	struct bmx_list_head parents_instance_list; //
 };
 
 struct opt_type {

--- a/lib/bmx7_tun/tun.c
+++ b/lib/bmx7_tun/tun.c
@@ -126,7 +126,7 @@ void set_tunXin6_net_adv_list_handl(uint8_t del, void **adv_list_ptr)
 	n = debugMallocReset(sizeof( struct tunXin6_net_adv_list_node), -300517);
 
 	n->adv_list = adv_list;
-	list_add_tail((&tunXin6_net_adv_list_list), &n->list);
+	bmx_list_add_tail((&tunXin6_net_adv_list_list), &n->list);
 }
 
 STATIC_FUNC

--- a/list.c
+++ b/list.c
@@ -39,7 +39,7 @@
  * @head: list head of maintained nodes
  * @node: a node maintained in the list or NULL
  */
-void * list_iterate(struct list_head *head, void *node)
+void * list_iterate(struct bmx_list_head *head, void *node)
 {
 	struct list_node *ln = (node ?
 		((struct list_node*) (((char*) node) + head->list_node_offset)) :
@@ -53,7 +53,7 @@ void * list_iterate(struct list_head *head, void *node)
 	return(((char*) ln->next) - head->list_node_offset);
 }
 
-void *list_find_next(struct list_head *head, void* key, void *node)
+void *list_find_next(struct bmx_list_head *head, void* key, void *node)
 {
 	while ((node = list_iterate(head, node))) {
 
@@ -68,7 +68,7 @@ void *list_find_next(struct list_head *head, void* key, void *node)
  * @head: list head to add it after
  * @new: new entry to be added
  */
-void list_add_head(struct list_head *head, struct list_node *new)
+void list_add_head(struct bmx_list_head *head, struct list_node *new)
 {
 
 	new->next = head->next;
@@ -82,12 +82,12 @@ void list_add_head(struct list_head *head, struct list_node *new)
 }
 
 /**
- * list_add_tail - add a new entry
+ * bmx_list_add_tail - add a new entry
  * @head: list head to add it before
  * @new: new entry to be added
  */
 
-void list_add_tail(struct list_head *head, struct list_node *new)
+void bmx_list_add_tail(struct bmx_list_head *head, struct list_node *new)
 {
 	new->next = (struct list_node *) head;
 	head->last->next = new;
@@ -96,7 +96,7 @@ void list_add_tail(struct list_head *head, struct list_node *new)
 	head->items++;
 }
 
-void list_add_after(struct list_head *head, struct list_node *ln, struct list_node *new)
+void list_add_after(struct bmx_list_head *head, struct list_node *ln, struct list_node *new)
 {
 	new->next = ln->next;
 	ln->next = new;
@@ -112,7 +112,7 @@ void list_add_after(struct list_head *head, struct list_node *ln, struct list_no
  * @entry: the element to delete from the list.
  * Note: list_empty on entry does not return true after this, the entry is in an undefined state.
  */
-void list_del_next(struct list_head *head, struct list_node *ln)
+void list_del_next(struct bmx_list_head *head, struct list_node *ln)
 {
 	assertion(-502641, (ln->next != (struct list_node*) head));
 
@@ -126,7 +126,7 @@ void list_del_next(struct list_head *head, struct list_node *ln)
 	head->items--;
 }
 
-void *list_del_head(struct list_head *head)
+void *list_del_head(struct bmx_list_head *head)
 {
 	if (LIST_EMPTY(head))
 		return NULL;
@@ -147,7 +147,7 @@ void *list_del_head(struct list_head *head)
  */
 
 /* UNTESTED
-void * plist_iterate(struct list_head *head, struct plist_node **pln)
+void * plist_iterate(struct bmx_list_head *head, struct plist_node **pln)
 {
 
 	if (head->last == (struct list_node*)
@@ -169,17 +169,17 @@ static struct plist_node *plist_node_create(void *item)
 	return plh;
 }
 
-void plist_add_head(struct list_head *head, void *item)
+void plist_add_head(struct bmx_list_head *head, void *item)
 {
 	list_add_head(head, &((plist_node_create(item))->list));
 }
 
-void plist_add_tail(struct list_head *head, void *item)
+void plist_add_tail(struct bmx_list_head *head, void *item)
 {
-	list_add_tail(head, &((plist_node_create(item))->list));
+	bmx_list_add_tail(head, &((plist_node_create(item))->list));
 }
 
-void * plist_del_head(struct list_head *head)
+void * plist_del_head(struct bmx_list_head *head)
 {
 	struct plist_node *pln = list_del_head(head);
 

--- a/list.h
+++ b/list.h
@@ -28,7 +28,7 @@
 
 
 #ifndef _LIST_H
-#define _LIST_H
+#define _LIST_H_
 
 #include <stdint.h>
 
@@ -36,7 +36,7 @@ struct list_node {
 	struct list_node *next;
 };
 
-struct list_head {
+struct bmx_list_head {
 	struct list_node *next;
 	struct list_node *last;
 	uint16_t items;
@@ -52,7 +52,7 @@ struct plist_node {
 
 
 
-#define LIST_SIMPEL(ptr, element_type, list_field, key_field ) struct list_head ptr = { \
+#define LIST_SIMPEL(ptr, element_type, list_field, key_field ) struct bmx_list_head ptr = { \
           .next = (struct list_node *)&ptr, \
           .last = (struct list_node *)&ptr,    \
           .items = 0, \
@@ -75,14 +75,14 @@ struct plist_node {
 #define list_get_first(head) ((void*)((LIST_EMPTY(head)) ? NULL : (((char*) (head)->next) - (head)->list_node_offset) ))
 #define list_get_last(head) ((void*)((LIST_EMPTY(head)) ? NULL : (((char*) (head)->last) - (head)->list_node_offset) ))
 
-void *list_iterate(struct list_head *head, void *node);
-void *list_find_next(struct list_head *head, void* key, void *node);
+void *list_iterate(struct bmx_list_head *head, void *node);
+void *list_find_next(struct bmx_list_head *head, void* key, void *node);
 
-void list_add_head(struct list_head *head, struct list_node * new);
-void list_add_tail(struct list_head *head, struct list_node * new);
-void list_add_after(struct list_head *head, struct list_node *pos, struct list_node * new);
-void list_del_next(struct list_head *head, struct list_node *pos);
-void *list_del_head(struct list_head *head);
+void list_add_head(struct bmx_list_head *head, struct list_node * new);
+void bmx_list_add_tail(struct bmx_list_head *head, struct list_node * new);
+void list_add_after(struct bmx_list_head *head, struct list_node *pos, struct list_node * new);
+void list_del_next(struct bmx_list_head *head, struct list_node *pos);
+void *list_del_head(struct bmx_list_head *head);
 
 
 #define plist_get_first(head) (LIST_EMPTY(head) ? NULL : \
@@ -91,17 +91,17 @@ void *list_del_head(struct list_head *head);
 #define plist_get_last(head) (LIST_EMPTY(head) ? NULL : \
                               ((struct plist_node*)(((char*) (head)->prev) - (head)->list_node_offset))-item )
 
-void * plist_iterate(struct list_head *head, struct plist_node **pln);
+void * plist_iterate(struct bmx_list_head *head, struct plist_node **pln);
 
-void plist_add_head(struct list_head *head, void *item);
-void plist_add_tail(struct list_head *head, void *item);
-void *plist_del_head(struct list_head *head);
+void plist_add_head(struct bmx_list_head *head, void *item);
+void plist_add_tail(struct bmx_list_head *head, void *item);
+void *plist_del_head(struct bmx_list_head *head);
 
 
 
 /**
  * list_entry - get the struct for this entry
- * @ptr:	the &struct list_head pointer.
+ * @ptr:	the &struct bmx_list_head pointer.
  * @type:	the type of the struct this is embedded in.
  * @member:	the name of the list_struct within the struct.
  */
@@ -109,7 +109,7 @@ void *plist_del_head(struct list_head *head);
 
 /**
  * list_for_each	-	iterate over a list
- * @pos:	the &struct list_head to use as a loop counter.
+ * @pos:	the &struct bmx_list_head to use as a loop counter.
  * @head:	the head for your list.
  */
 #define list_for_each(pos, head) \
@@ -123,8 +123,8 @@ void *plist_del_head(struct list_head *head);
 
 /**
  * list_for_each_safe	-	iterate over a list safe against removal of list entry
- * @pos:	the &struct list_head to use as a loop counter.
- * @n:		another &struct list_head to use as temporary storage
+ * @pos:	the &struct bmx_list_head to use as a loop counter.
+ * @n:		another &struct bmx_list_head to use as temporary storage
  * @head:	the head for your list.
  */
 #define list_for_each_safe(pos, n, head) \

--- a/msg.h
+++ b/msg.h
@@ -357,7 +357,7 @@ struct tx_frame_iterator {
 	// MUST be initialized:
 	// remains unchanged:
 	const char *caller;
-	struct list_head *tx_task_list;
+	struct bmx_list_head *tx_task_list;
 	struct tx_task_node *ttn;
 	//	struct desc_contents *descContents;
 	struct frame_db *db;

--- a/plugin.c
+++ b/plugin.c
@@ -74,7 +74,7 @@ void _set_thread_hook(int32_t cb_type, void (*cb_handler) (void), int8_t del, st
 		cleanup_all(-500143);
 	}
 
-	list_for_each_safe(list_pos, tmp_pos, (struct list_head*) cb_list)
+	list_for_each_safe(list_pos, tmp_pos, (struct bmx_list_head*) cb_list)
 	{
 		cbn = list_entry(list_pos, struct cb_node, list);
 
@@ -82,7 +82,7 @@ void _set_thread_hook(int32_t cb_type, void (*cb_handler) (void), int8_t del, st
 
 			if (del) {
 
-				list_del_next(((struct list_head*) cb_list), prev_pos);
+				list_del_next(((struct bmx_list_head*) cb_list), prev_pos);
 				debugFree(cbn, -300069);
 				return;
 
@@ -103,7 +103,7 @@ void _set_thread_hook(int32_t cb_type, void (*cb_handler) (void), int8_t del, st
 
 	cbn->cb_type = cb_type;
 	cbn->cb_handler = cb_handler;
-	list_add_tail(((struct list_head*) cb_list), &cbn->list);
+	bmx_list_add_tail(((struct bmx_list_head*) cb_list), &cbn->list);
 
 }
 
@@ -261,7 +261,7 @@ int activate_plugin(struct plugin *p, void *dlhandle, const char *dl_name)
 	pn->plugin = p;
 	pn->dlhandle = dlhandle;
 
-	list_add_tail(&plugin_list, &pn->list);
+	bmx_list_add_tail(&plugin_list, &pn->list);
 
 	dbgf_all(DBGT_INFO, "%s SUCCESS", pn->plugin->plugin_name);
 

--- a/plugin.h
+++ b/plugin.h
@@ -74,7 +74,7 @@ struct cb_fd_node {
 	void (*cb_fd_handler) (int32_t fd);
 };
 
-extern struct list_head cb_fd_list;
+extern struct bmx_list_head cb_fd_list;
 // cb_fd_handler is called when fd received data
 // called function may remove itself
 void set_fd_hook(int32_t fd, void (*cb_fd_handler) (int32_t fd), int8_t del);

--- a/schedule.c
+++ b/schedule.c
@@ -205,7 +205,7 @@ void task_register(TIME_T timeout, void (* task) (void *), void *data, int32_t t
 	}
 
 	if ((tmp_tn == NULL) || (U32_LE(tmp_tn->expire, tn->expire)))
-		list_add_tail(&task_list, &tn->list);
+		bmx_list_add_tail(&task_list, &tn->list);
 
 }
 

--- a/tun.h
+++ b/tun.h
@@ -309,7 +309,7 @@ struct tunXin6_net_adv_list_node {
 };
 
 
-extern struct list_head tunXin6_net_adv_list_list;
+extern struct bmx_list_head tunXin6_net_adv_list_list;
 
 struct tun_bit_key_nodes {
 	struct tun_search_node *tsn;


### PR DESCRIPTION
Rename some list stuff to avoid namespace collision with libubox.
Unfortunately the list implementation in bmx7 grew too much apart from what is included in libubox today, so simply rename the currently colliding names so they can co-exist.
Fixes build of bmx7_iwinfo which indirectly includes libubox.