### PR TITLE
Linux changed the header file for SIOCGSTAMP

### DIFF
--- a/src/schedule.c
+++ b/src/schedule.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <linux/sockios.h>
 
 
 #include "list.h"


### PR DESCRIPTION
This fixes bmx7 not building with Linux 5.3 (and possibly earlier)

Signed-off-by: Arne Zachlod <arne@nerdkeller.org>