### PR TITLE
Add missing extern keyword

### DIFF
--- a/src/bmx.h
+++ b/src/bmx.h
@@ -290,7 +290,7 @@ enum ADGSN {
 #define SUCCESS 0
 #define FAILURE -1
 
-const void* FAILURE_PTR;
+extern const void* FAILURE_PTR;
 
 
 #define MAX_SELECT_TIMEOUT_MS 1100 /* MUST be smaller than (1000/2) to fit into max tv_usec */


### PR DESCRIPTION
Otherwise linking might fail
because of duplicate symbols.